### PR TITLE
Create a per-build temp directory

### DIFF
--- a/src/build-api.js
+++ b/src/build-api.js
@@ -35,8 +35,12 @@ export async function determineBuildCommand(rootPath, sha) {
   return ret;
 }
 
-export function runBuildCommand(cmd, args, rootDir, sha) {
-  let envToAdd = { 'SERF_SHA1': sha };
+export function runBuildCommand(cmd, args, rootDir, sha, tempDir) {
+  let envToAdd = { 
+    'SERF_SHA1': sha,
+    'TMPDIR': tempDir,
+    'TEMP': tempDir
+  };
 
   let opts = {
     cwd: rootDir,

--- a/src/build-project-cli.js
+++ b/src/build-project-cli.js
@@ -4,6 +4,7 @@ import './babel-maybefill';
 
 import path from 'path';
 import mkdirp from 'mkdirp';
+import fs from 'fs';
 import { cloneOrFetchRepo, cloneRepo, checkoutSha, getWorkdirForRepoUrl } from './git-api';
 import { getNwoFromRepoUrl, postCommitStatus, createGist } from './github-api';
 import { determineBuildCommand, runBuildCommand } from './build-api';
@@ -98,9 +99,12 @@ async function main() {
     buildPassed = true;
   } catch (e) {
     buildOutput = e.message;
+
     console.log(`Error during build: ${e.message}`);
     d(e.stack);
   }
+  
+  fs.writeFileSync(path.join(workDir, 'build-output.log'), buildOutput);
 
   if (argv.name) {
     d(`Posting 'success' to GitHub status`);

--- a/src/clean-workdirs-cli.js
+++ b/src/clean-workdirs-cli.js
@@ -48,6 +48,7 @@ async function main() {
 
   let safeDirs = _.reduce(refInfo, (acc, ref) => {
     acc.add(getWorkdirForRepoUrl(argv.r, ref.object.sha, true));
+    acc.add(getTempdirForRepoUrl(argv.r, ref.object.sha, true));
     return acc;
   }, new Set());
   

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -39,6 +39,16 @@ export function getWorkdirForRepoUrl(repoUrl, sha, dontCreate=false) {
   return ret;
 }
 
+export function getTempdirForRepoUrl(repoUrl, sha, dontCreate=false) {
+  let tmp = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  let nwo = getNwoFromRepoUrl(repoUrl).split('/')[1];
+  let date = toIso8601(new Date()).replace(/:/g, '.');
+  let shortSha = sha.substr(0,6);
+
+  let ret = path.join(tmp, `serftmp-${nwo}-${shortSha}-${date}`);
+  if (!dontCreate) mkdirp.sync(ret);
+  return ret;
+}
 export async function checkoutSha(targetDirname, sha) {
   let repo = await Repository.open(targetDirname);
   let commit = await repo.getCommit(sha);

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -21,7 +21,7 @@ export async function getAllWorkdirs() {
   let ret = await fs.readdir(tmp);
 
   return _.reduce(ret, (acc, x) => {
-    if (!x.match(/^serf-workdir/i)) return acc;
+    if (!x.match(/^serf(tmp)?-/i)) return acc;
 
     acc.push(path.join(tmp, x));
     return acc;


### PR DESCRIPTION
Set up a temp directory for builds and trash that directory once we successfully build (leave it around if it fails for debugging).